### PR TITLE
Add Tier 2 operator documentation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ See the [Triton Comms Guide](docs/triton_comms.md) for usage details.
 | Sampling | Greedy, random, mixed, top-k, top-p token sampling for LLM generation | [Sampling Guide](docs/sampling_guide.md) |
 | Top-K | Top-k selection — MOE routing (grouped, biased), radix/bitonic sort, fused softmax+topk | [Top-K Guide](docs/topk_guide.md) |
 | Communication (AllReduce) | Custom all-reduce, quick all-reduce, Iris reduce-scatter/all-gather | [Distributed Guide](docs/distributed_guide.md) |
+| Causal Conv1D | Causal convolution for Mamba/SSM models — prefill, decode, fused QKV split, speculative decoding | [Causal Conv1D Guide](docs/causal_conv1d_guide.md) |
+| Gated Delta Net | Gated delta rule recurrence — fused recurrent, chunk-based, sigmoid gating, GVA support | [GDN Guide](docs/gated_delta_net_guide.md) |
+| Grouped GEMM | GMM (Triton) and DeepGEMM (CK) — MoE expert routing, variable-length grouped GEMM | [Grouped GEMM Guide](docs/grouped_gemm_guide.md) |
 
 Each guide covers available variants, backend support (ASM / CK / Triton), Python API examples, and performance tuning advice.
 
@@ -78,6 +81,8 @@ Run operator tests with: `python3 op_tests/<test_file>.py` (e.g. `python3 op_tes
 | [JIT Compilation System](docs/jit_system_guide.md) | `@compile_ops` decorator, module config, build flow, cache, GPU detection |
 | [GEMM Tuning & Gradlib](docs/gemm_tuning_guide.md) | CSV-based kernel dispatch, hipBLASLt/ASM tuning, gradlib framework |
 | [Distributed Infrastructure](docs/distributed_guide.md) | Tensor parallelism, custom/quick all-reduce, Iris comms, shared memory broadcast |
+| [Weight Shuffle & Preshuffle](docs/weight_shuffle_guide.md) | Weight layout transforms for CK/ASM/Triton GEMM, FP8/FP4 preshuffle |
+| [BERT Padding & Variable-Length](docs/bert_padding_guide.md) | Pad/unpad utilities, variable-length attention, cumulative sequence lengths |
 
 ## Additional Resources
 - [Triton-based Communication (Iris)](docs/triton_comms.md) — GPU-initiated reduce-scatter and all-gather

--- a/docs/bert_padding_guide.md
+++ b/docs/bert_padding_guide.md
@@ -1,0 +1,186 @@
+# AITER BERT Padding & Variable-Length Sequence Guide
+
+This guide documents the padding/unpadding utilities and variable-length sequence handling in AITER, enabling efficient attention computation on batches with different sequence lengths.
+
+---
+
+## Quick Reference
+
+| Use Case | Function | Description |
+|----------|---------|-------------|
+| **Remove padding** | `unpad_input(hidden_states, attention_mask)` | Batch → packed sequences |
+| **Restore padding** | `pad_input(hidden_states, indices, batch, seqlen)` | Packed → batch format |
+| **Concatenated sequences** | `unpad_input_for_concatenated_sequences(...)` | SFT-style concatenated samples |
+| **Variable-length attention** | `flash_attn_varlen_func(...)` | Flash attention on packed inputs |
+
+---
+
+## 1. Padding / Unpadding Utilities
+
+### `unpad_input`
+
+Removes padding tokens from batch-formatted tensors to create packed sequences:
+
+```python
+from aiter.bert_padding import unpad_input
+
+hidden_states_unpad, indices, cu_seqlens, max_seqlen, seqused = unpad_input(
+    hidden_states,      # (batch, seqlen, ...) — padded input
+    attention_mask,     # (batch, seqlen) — 1=valid, 0=padding
+    unused_mask=None,   # (batch, seqlen) — 1=allocated but unused (optional)
+)
+# hidden_states_unpad: (total_nnz, ...) — packed valid tokens
+# indices: (total_nnz,) — indices into flattened input
+# cu_seqlens: (batch+1,) — cumulative sequence lengths
+# max_seqlen: int — longest sequence
+# seqused: (batch,) — tokens selected per batch element
+```
+
+### `pad_input`
+
+Restores packed sequences to padded batch format (inverse of `unpad_input`):
+
+```python
+from aiter.bert_padding import pad_input
+
+hidden_states = pad_input(
+    hidden_states_unpad, # (total_nnz, ...) — packed tokens
+    indices,             # (total_nnz,) — from unpad_input
+    batch,               # int — batch size
+    seqlen,              # int — max sequence length
+)
+# hidden_states: (batch, seqlen, ...) — zero-padded output
+```
+
+### `unpad_input_for_concatenated_sequences`
+
+For supervised fine-tuning where multiple short samples are concatenated:
+
+```python
+from aiter.bert_padding import unpad_input_for_concatenated_sequences
+
+hidden_states_unpad, indices, cu_seqlens, max_seqlen = unpad_input_for_concatenated_sequences(
+    hidden_states,              # (batch, seqlen, ...)
+    attention_mask_in_length,   # (batch, seqlen) — nonzero=length of concat'd sequence
+)
+```
+
+---
+
+## 2. Variable-Length Flash Attention
+
+After unpadding, use variable-length flash attention:
+
+```python
+import aiter
+
+out_unpad = aiter.flash_attn_varlen_func(
+    q_unpad,            # (total_q, nheads, headdim)
+    k_unpad,            # (total_k, nheads_k, headdim)
+    v_unpad,            # (total_k, nheads_k, headdim_v)
+    cu_seqlens_q,       # (batch+1,) int32
+    cu_seqlens_k,       # (batch+1,) int32
+    max_seqlen_q,       # int
+    max_seqlen_k,       # int
+    causal=True,
+    softmax_scale=None,
+    # Optional physical padding support:
+    cu_seqlens_q_padded=None,
+    cu_seqlens_k_padded=None,
+)
+```
+
+**Backends:** CK (primary), FMHA v3 (bf16, hdim 128/192), Triton
+
+---
+
+## 3. End-to-End Example
+
+```python
+import torch
+import aiter
+from aiter.bert_padding import unpad_input, pad_input
+from aiter.test_mha_common import generate_qkv
+
+batch_size, seqlen_q, seqlen_k = 4, 512, 512
+nheads, d = 32, 128
+
+# Padded inputs
+q = torch.randn(batch_size, seqlen_q, nheads, d, device="cuda", dtype=torch.bfloat16)
+k = torch.randn(batch_size, seqlen_k, nheads, d, device="cuda", dtype=torch.bfloat16)
+v = torch.randn(batch_size, seqlen_k, nheads, d, device="cuda", dtype=torch.bfloat16)
+
+# Random padding masks (actual sequence lengths vary)
+query_padding_mask = torch.ones(batch_size, seqlen_q, device="cuda", dtype=torch.bool)
+key_padding_mask = torch.ones(batch_size, seqlen_k, device="cuda", dtype=torch.bool)
+query_padding_mask[0, 300:] = False  # First sequence is 300 tokens
+key_padding_mask[0, 300:] = False
+
+# Unpad
+q_unpad, indices_q, cu_seqlens_q, max_seqlen_q, _ = unpad_input(q, query_padding_mask)
+k_unpad, _, cu_seqlens_k, max_seqlen_k, _ = unpad_input(k, key_padding_mask)
+v_unpad, _, _, _, _ = unpad_input(v, key_padding_mask)
+
+# Run attention on packed sequences (no wasted computation on padding)
+out_unpad = aiter.flash_attn_varlen_func(
+    q_unpad, k_unpad, v_unpad,
+    cu_seqlens_q, cu_seqlens_k,
+    max_seqlen_q, max_seqlen_k,
+    causal=True,
+)
+
+# Restore to padded format
+out = pad_input(out_unpad, indices_q, batch_size, seqlen_q)
+```
+
+---
+
+## 4. Implementation Details
+
+### Custom Autograd Functions
+
+The module uses optimized `torch.gather`/`torch.scatter` instead of boolean indexing:
+
+| Function | Forward | Backward |
+|----------|---------|----------|
+| `IndexFirstAxis` | `torch.gather` | `torch.scatter` |
+| `IndexPutFirstAxis` | `torch.scatter` | `torch.gather` |
+| `IndexFirstAxisResidual` | Index + residual pass-through | scatter-add |
+
+### Tensor Formats
+
+| Format | Shape | Description |
+|--------|-------|-------------|
+| **Padded** | `(batch, seqlen, nheads, hdim)` | Standard batch format |
+| **Unpadded** | `(total_tokens, nheads, hdim)` | Packed valid tokens |
+| **cu_seqlens** | `(batch+1,)` int32 | Cumulative lengths, starts at 0 |
+
+---
+
+## 5. Supported Data Types
+
+| dtype | Notes |
+|-------|-------|
+| float16 | Fully supported |
+| bfloat16 | Preferred for FMHA v3 |
+| float8_e4m3fn/fnuz | With descaling parameters |
+
+---
+
+## 6. Source Files
+
+| Component | Path |
+|---|---|
+| Padding utilities | `aiter/bert_padding.py` |
+| Variable-length attention API | `aiter/ops/mha.py` |
+| Test utilities (generate_qkv) | `aiter/test_mha_common.py` |
+| CK attention kernels | `csrc/include/torch/mha_varlen_fwd.h` |
+
+---
+
+## 7. Test Files
+
+| Test | Path |
+|------|------|
+| Variable-length MHA | `op_tests/test_mha_varlen.py` |
+| Variable-length MHA (FP8) | `op_tests/test_mha_varlen_fp8.py` |

--- a/docs/causal_conv1d_guide.md
+++ b/docs/causal_conv1d_guide.md
@@ -1,0 +1,182 @@
+# AITER Causal Conv1D Operators Guide
+
+This guide documents the Causal Conv1D operators in AITER, used in Mamba-style state-space models and gated architectures for sequence modeling with causal (left-only) convolution.
+
+---
+
+## Quick Reference
+
+| Use Case | Recommended Operation | Backend | Why |
+|----------|---------------------|---------|-----|
+| **Prefill (variable-length)** | `causal_conv1d_fn` | Triton | Continuous batching, ragged sequences |
+| **Decode (single/multi-token)** | `causal_conv1d_update` | Triton | State caching, speculative decoding |
+| **Fused conv + QKV split (prefill)** | `causal_conv1d_fn_split_qkv` | Triton | Avoids intermediate allocation |
+| **Fused conv + QKV split (decode)** | `causal_conv1d_update_split_qkv` | Triton | Gluon-optimized variants |
+
+---
+
+## 1. Core Operations
+
+### `causal_conv1d_fn` (Forward / Prefill)
+
+Variable-length forward pass with continuous batching support:
+
+```python
+from aiter.ops.triton.causal_conv1d import causal_conv1d_fn
+
+out = causal_conv1d_fn(
+    x,                      # (dim, cu_seqlen) — concatenated tokens, channel-last
+    weight,                 # (dim, width) — convolution weights
+    bias,                   # (dim,) or None
+    conv_states=conv_states,        # (num_cache_lines, dim, width-1) — state cache
+    query_start_loc=query_start_loc, # (batch+1,) int32 — cumulative seq lengths
+    seq_lens_cpu=seq_lens_cpu,       # List[int] — per-sequence lengths (CPU)
+    cache_indices=cache_indices,     # (batch,) int32 — maps seq to cache slot
+    has_initial_state=has_initial_state, # (batch,) bool — load existing state
+    activation="silu",      # "silu", "swish", or None
+    pad_slot_id=-1,         # sentinel for padded sequences
+)
+```
+
+**Features:**
+- Continuous batching via `cache_indices` for cache slot indirection
+- Variable-length sequences via `query_start_loc` (ragged batching)
+- Automatic state save/restore for stateful processing
+- Kernel widths: 2, 3, 4, 5
+
+### `causal_conv1d_update` (Decode)
+
+Single or multi-token update for autoregressive generation:
+
+```python
+from aiter.ops.triton.causal_conv1d import causal_conv1d_update
+
+out = causal_conv1d_update(
+    x,                      # (batch, dim, seqlen) or (batch, dim)
+    conv_state,             # (num_cache_lines, dim, state_len)
+    weight,                 # (dim, width)
+    bias=None,
+    activation="silu",
+    conv_state_indices=indices,      # (batch,) int32 — cache line mapping
+    num_accepted_tokens=accepted,    # (batch,) — for speculative decoding
+    intermediate_conv_window=window, # saves intermediate states
+    pad_slot_id=-1,
+)
+```
+
+**Features:**
+- Single token decode and multi-token speculative decoding
+- `num_accepted_tokens` for token rollback in speculative decoding
+- `intermediate_conv_window` for saving per-step window states
+- Kernel widths: 2, 3, 4
+
+---
+
+## 2. Fused QKV Split Variants
+
+For Gated Delta Net models, fused operations perform causal conv1d **and** split output into Q/K/V, avoiding intermediate tensor allocation.
+
+### Prefill
+
+```python
+from aiter.ops.triton._triton_kernels.gated_delta_rule.prefill.causal_conv1d_fwd_split_qkv import (
+    causal_conv1d_fn_split_qkv
+)
+
+q, k, v = causal_conv1d_fn_split_qkv(
+    x,              # (dim, cu_seqlen) where dim = 2*k_dim + v_dim
+    weight, bias, conv_states,
+    query_start_loc, seq_lens_cpu,
+    k_dim=128,      # query and key dimension
+    v_dim=128,      # value dimension
+    activation="silu",
+)
+# q: (cu_seqlen, k_dim), k: (cu_seqlen, k_dim), v: (cu_seqlen, v_dim)
+```
+
+### Decode
+
+```python
+from aiter.ops.triton._triton_kernels.gated_delta_rule.decode.causal_conv1d_split_qkv import (
+    causal_conv1d_update_split_qkv
+)
+
+q, k, v = causal_conv1d_update_split_qkv(
+    x,              # (batch, dim, seqlen) where dim = 2*key_dim + value_dim
+    conv_state, weight,
+    key_dim=128, value_dim=128,
+    activation="silu",
+    use_gluon=True,     # Gluon kernel (default)
+    use_gluon_v2=False, # Optimized Gluon v2
+)
+# q, k: (batch, key_dim, seqlen), v: (batch, value_dim, seqlen)
+```
+
+**Decode kernel variants:**
+1. Standard Triton
+2. Optimized v2 (multi-CU utilization)
+3. Gluon (experimental Triton frontend)
+4. Gluon v2 (eliminates tuple operations for better register allocation)
+
+---
+
+## 3. Layout Requirements
+
+All operators require **channel-last** input layout (`x.stride(0) == 1`) for coalesced memory access.
+
+| Tensor | Shape | Notes |
+|--------|-------|-------|
+| `x` (prefill) | `(dim, cu_seqlen)` | Channel-last, concatenated sequences |
+| `x` (decode) | `(batch, dim, seqlen)` | `seqlen=1` for single-token decode |
+| `weight` | `(dim, width)` | Shared across all sequences |
+| `conv_states` | `(num_cache_lines, dim, width-1)` | Indexed via `cache_indices` |
+
+---
+
+## 4. Supported Data Types
+
+| Input | Tolerance |
+|-------|-----------|
+| float32 | rtol=3e-4, atol=1e-3 |
+| bfloat16 | rtol=1e-2, atol=5e-2 |
+
+---
+
+## 5. Backend Support
+
+All implementations are **Triton-only** — no CUDA/HIP/CK/ASM kernels.
+
+| Operator | Triton | Gluon |
+|----------|:------:|:-----:|
+| `causal_conv1d_fn` | Yes | — |
+| `causal_conv1d_update` | Yes | — |
+| `causal_conv1d_fn_split_qkv` | Yes | — |
+| `causal_conv1d_update_split_qkv` | Yes | Yes (v1, v2) |
+
+---
+
+## 6. Performance Notes
+
+- **Block sizes:** BLOCK_M=8 (tokens), BLOCK_N=256 (features), 2-stage software pipelining
+- **State management:** Uses `.ca` cache modifier for prior token loads (L2 cache hints)
+- **Gluon v2:** Eliminates tuple operations in hot loops for better register allocation and multi-CU utilization
+- **In-place output:** Update kernel writes directly to input tensor `x`
+
+---
+
+## 7. Source Files
+
+| Component | Path |
+|---|---|
+| Core Python API | `aiter/ops/triton/causal_conv1d.py` |
+| Triton kernels | `aiter/ops/triton/_triton_kernels/causal_conv1d.py` |
+| Fused prefill split QKV | `aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/causal_conv1d_fwd_split_qkv.py` |
+| Fused decode split QKV | `aiter/ops/triton/_triton_kernels/gated_delta_rule/decode/causal_conv1d_split_qkv.py` |
+
+---
+
+## 8. Test Files
+
+| Test | Path |
+|------|------|
+| Core causal conv1d | `op_tests/triton_tests/test_causal_conv1d.py` |

--- a/docs/gated_delta_net_guide.md
+++ b/docs/gated_delta_net_guide.md
@@ -1,0 +1,187 @@
+# AITER Gated Delta Net Operators Guide
+
+This guide documents the Gated Delta Net (GDN) operators in AITER, implementing the gated delta rule recurrent mechanism for linear attention models. These are **forward-only** inference implementations adapted from flash-linear-attention.
+
+---
+
+## Quick Reference
+
+| Use Case | Recommended Operation | When to Use |
+|----------|---------------------|-------------|
+| **Autoregressive decode** | `fused_recurrent_gated_delta_rule` | Short sequences, low memory |
+| **Long-sequence prefill** | `chunk_gated_delta_rule` | Sequences > 1024 tokens |
+| **Fused sigmoid gating** | `fused_sigmoid_gating_delta_rule_update` | Models with sigmoid gate parameterization |
+
+---
+
+## 1. Fused Recurrent (Decode / Short Sequences)
+
+Processes sequences step-by-step in a single fused kernel. Optimal for autoregressive generation.
+
+```python
+from aiter.ops.triton.gated_delta_net import fused_recurrent_gated_delta_rule
+
+o, final_state = fused_recurrent_gated_delta_rule(
+    q,              # [B, T, H, K] — queries
+    k,              # [B, T, H, K] — keys
+    v,              # [B, T, HV, V] — values (HV >= H for GVA)
+    g=g,            # [B, T, HV] — global gate/decay (log space), optional
+    gk=gk,          # [B, T, HV, K] — per-key gate (log space), optional
+    gv=gv,          # [B, T, HV, V] — per-value gate (log space), optional
+    beta=beta,      # [B, T, HV] or [B, T, HV, V] — beta parameter
+    scale=None,     # defaults to 1/sqrt(K)
+    initial_state=h0,  # [N, HV, K, V] — initial hidden state
+    output_final_state=True,
+    use_qk_l2norm_in_kernel=False,
+    cu_seqlens=None,    # [N+1] for variable-length sequences
+)
+# o: [B, T, HV, V], final_state: [N, HV, K, V]
+```
+
+**Delta rule update (per step):**
+```
+h = h * exp(g)                          # Apply decay
+v_new = beta * (v - sum(h * k, dim=-2)) # Delta rule
+h = h + k[:, :, None] * v_new[:, None, :] # Update
+o = sum(h * q, dim=-2)                  # Output
+```
+
+**Features:**
+- Grouped Value Attention (GVA): `HV > H` allows more value heads than query/key heads
+- Three gating modes: global (`g`), per-key (`gk`), per-value (`gv`)
+- Variable-length sequences via `cu_seqlens`
+- Memory: O(B × HV × K × V) for hidden state
+
+---
+
+## 2. Chunk-Based (Prefill / Long Sequences)
+
+Divides sequences into 64-token chunks for parallel processing. Better throughput for long sequences.
+
+```python
+from aiter.ops.triton.gated_delta_net import chunk_gated_delta_rule
+
+o, final_state = chunk_gated_delta_rule(
+    q,              # [B, T, H, K]
+    k,              # [B, T, H, K]
+    v,              # [B, T, H, V]
+    g,              # [B, T, H] — gate/decay (log space, required)
+    beta,           # [B, T, H] — beta parameter (required)
+    scale=None,
+    initial_state=h0,  # [N, H, K, V]
+    output_final_state=True,
+    cu_seqlens=None,
+)
+```
+
+**Chunk processing pipeline:**
+1. `chunk_local_cumsum` — cumulative gates within chunks
+2. `chunk_scaled_dot_kkt_fwd` — WY representation (K @ K^T)
+3. `solve_tril` — triangular system solve
+4. `recompute_w_u_fwd` — recompute W and U matrices
+5. `chunk_gated_delta_rule_fwd_h` — hidden state updates
+6. `chunk_fwd_o` — final output
+
+**Constraints:** K ≤ 256 (uses 64-dim blocks, max 4 blocks), chunk size fixed at 64.
+
+---
+
+## 3. Fused Sigmoid Gating
+
+Combines sigmoid gating computation with delta rule update in a single kernel:
+
+```python
+from aiter.ops.triton._triton_kernels.gated_delta_rule.decode.fused_sigmoid_gating_recurrent import (
+    fused_sigmoid_gating_delta_rule_update
+)
+
+o, final_state = fused_sigmoid_gating_delta_rule_update(
+    q, k, v,
+    A_log,          # [HV] — log space gate parameter
+    a,              # [B, T, HV] — gate activation
+    dt_bias,        # [HV] — delta time bias
+    softplus_beta,  # float — softplus beta
+    softplus_threshold, # float — softplus threshold
+    b,              # [B, T, HV] — beta logits
+    initial_state=h0,
+    output_final_state=True,
+)
+```
+
+**Computes internally:**
+- `g = -exp(A_log) * softplus(a + dt_bias, beta, threshold)`
+- `beta = sigmoid(b)`
+
+---
+
+## 4. Supported Data Types
+
+| Tensor | Supported dtypes | Notes |
+|--------|-----------------|-------|
+| q, k | float16, bfloat16, float32 | Internally converted to float32 |
+| v, beta, g | float16, bfloat16, float32 | — |
+| initial_state / final_state | float32 | Always float32 |
+| Accumulation | float32 | All internal computation |
+
+**Test tolerances:** fp16: 0.002, bf16: 0.005
+
+---
+
+## 5. Backend Support
+
+All implementations are **Triton-only**.
+
+**Hardware-specific tuning:**
+- NVIDIA Hopper: Reduced warp configs (2, 4 instead of 2, 4, 8, 16)
+- AMD ROCm: Limited num_stages (2, 3 instead of 2, 3, 4) due to compiler constraints
+- Shared memory checks for block size tuning
+
+**Environment variables:**
+| Variable | Description |
+|----------|-------------|
+| `FLA_USE_FAST_OPS=1` | Enable fast math operations |
+| `FLA_CACHE_RESULTS=1` | Enable autotune cache (default: on) |
+| `FLA_USE_CUDA_GRAPH=1` | Enable CUDA graphs (NVIDIA only) |
+| `FLA_USE_TMA=1` | Enable Tensor Memory Accelerator (Hopper+) |
+
+---
+
+## 6. Choosing Between Variants
+
+```
+Need gated delta rule inference?
+├── Short sequences (T < 512) or decode?
+│   └── fused_recurrent_gated_delta_rule()
+├── Long sequences (T > 1024)?
+│   └── chunk_gated_delta_rule()
+├── Sigmoid gate parameterization?
+│   └── fused_sigmoid_gating_delta_rule_update()
+└── Need training / backward pass?
+    └── Use flash-linear-attention library instead
+```
+
+---
+
+## 7. Source Files
+
+| Component | Path |
+|---|---|
+| Main module | `aiter/ops/triton/gated_delta_net/gated_delta_rule.py` |
+| Fused recurrent kernel | `aiter/ops/triton/_triton_kernels/gated_delta_rule/decode/fused_recurrent.py` |
+| Fused sigmoid gating | `aiter/ops/triton/_triton_kernels/gated_delta_rule/decode/fused_sigmoid_gating_recurrent.py` |
+| Chunk kernels | `aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk.py` |
+| Chunk hidden state | `aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_delta_h.py` |
+| Chunk output | `aiter/ops/triton/_triton_kernels/gated_delta_rule/prefill/chunk_o.py` |
+| Utility: L2 norm | `aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/l2norm.py` |
+| Utility: cumsum | `aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/cumsum.py` |
+| Utility: triangular solve | `aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/solve_tril.py` |
+| Utility: WY representation | `aiter/ops/triton/_triton_kernels/gated_delta_rule/utils/wy_representation.py` |
+| Fused causal conv1d split QKV | See [Causal Conv1D Guide](causal_conv1d_guide.md) |
+
+---
+
+## 8. Test Files
+
+| Test | Path |
+|------|------|
+| All GDN variants | `op_tests/triton_tests/test_gated_delta_rule.py` |

--- a/docs/grouped_gemm_guide.md
+++ b/docs/grouped_gemm_guide.md
@@ -1,0 +1,181 @@
+# AITER Grouped GEMM Operators Guide
+
+This guide documents the Grouped Matrix Multiply (GMM) and DeepGEMM operators in AITER, designed for Mixture-of-Experts (MoE) and variable-length grouped computations.
+
+---
+
+## Quick Reference
+
+| Use Case | Recommended Operation | Backend | Why |
+|----------|---------------------|---------|-----|
+| **MoE expert GEMM (forward)** | `gmm` | Triton | Token-to-expert routing, bias support |
+| **MoE expert GEMM (backward)** | `ptgmm` / `nptgmm` | Triton | Transposed GMM, bias gradient |
+| **Variable-length attention GEMM** | `deepgemm` | CK-tile | Dynamic masking, FP8 quantized |
+
+---
+
+## 1. GMM (Grouped Matrix Multiply) — Triton
+
+### `gmm` — Forward Pass
+
+Each group of rows in `lhs` is multiplied with the corresponding weight plane in `rhs`:
+
+```python
+from aiter.ops.triton.gmm import gmm
+
+out = gmm(
+    lhs,            # (M, K) — input activations
+    rhs,            # (G, K, N) — per-group weights
+    group_sizes,    # (G,) int32 — rows per group, must sum to M
+    preferred_element_type=torch.bfloat16,
+    bias=bias,      # (G, N) — optional per-group bias
+)
+# out: (M, N)
+```
+
+**Operation:** `out[start:end, :] = lhs[start:end, :] @ rhs[g] + bias[g]` for each group `g`.
+
+### `ptgmm` / `nptgmm` — Transposed GMM (Backward)
+
+Computes transposed grouped GEMM for weight gradient computation:
+
+```python
+from aiter.ops.triton.gmm import ptgmm, nptgmm
+
+out = ptgmm(
+    lhs,            # (K, M) — transposed input
+    rhs,            # (M, N) — gradient from downstream
+    group_sizes,    # (G,) int32
+    bias_grad=bg,   # (G, K) float32 — optional bias gradient output
+    accumulate=False, # accumulate into existing output
+)
+# out: (G, K, N)
+```
+
+**Operation:** `out[g] = lhs[:, start:end] @ rhs[start:end, :]` for each group `g`.
+
+`ptgmm` uses a persistent kernel; `nptgmm` uses a non-persistent variant. Benchmark both to choose.
+
+### Supported Data Types
+
+| Input | Output | Group sizes | Bias gradient |
+|-------|--------|-------------|---------------|
+| float16, bfloat16 | float16, bfloat16 | int32 | float32 |
+
+### Layout Requirements
+
+| Variant | `lhs` stride | `rhs` stride |
+|---------|-------------|-------------|
+| `gmm` | row-major `(K, 1)` | row-major `(K*N, N, 1)` or col-major `(K*N, 1, K)` |
+| `ptgmm`/`nptgmm` | row-major `(M, 1)` or col-major `(1, K)` | row-major `(N, 1)` |
+
+### Kernel Configuration
+
+Tuning configs stored in `aiter/ops/triton/configs/{arch}-GMM.json`:
+
+```json
+{
+  "gmm": {
+    "default": {
+      "BLOCK_SIZE_M": 128, "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64, "GROUP_SIZE": 8, "GRID_DIM": 256
+    }
+  }
+}
+```
+
+Auto-queried by `get_config(gmm_type, M, K, N, G)` with LRU caching.
+
+### Performance Notes
+
+- **Persistent kernel:** Processes multiple tiles across groups in a single program launch
+- **XCD remapping:** Improves L2 cache locality on multi-XCD GPUs (MI300)
+- **IEEE precision:** Uses `tl.dot(..., input_precision="ieee")` for numerical stability
+
+---
+
+## 2. DeepGEMM — CK-tile
+
+Grouped GEMM with dynamic per-group masking, optimized for variable-length attention workloads.
+
+```python
+import aiter
+from aiter import deepgemm
+from aiter.ops.shuffle import shuffle_weight
+
+# Weights must be pre-shuffled
+weight_shuffled = shuffle_weight(weight_q, layout=(16, 16))
+
+out = deepgemm(
+    XQ,             # (num_groups, max_m, k) — input activations
+    weight_shuffled, # (num_groups, n, k) — shuffled weights
+    Y,              # (num_groups, max_m, n) — preallocated output
+    group_layout,   # (num_groups,) int32 — active rows per group
+    x_scale=None,   # per-token activation scale (for FP8)
+    w_scale=None,   # per-group weight scale (for FP8)
+)
+```
+
+**Operation:** `Y[j, :masked_m[j], :] = XQ[j, :masked_m[j], :] @ WQ[j].T` for each group `j`.
+
+### Supported Data Types
+
+| Input/Weight | Output | Scale | Notes |
+|-------------|--------|-------|-------|
+| float16, bfloat16 | Same as input | None | No quantization |
+| float8_e4m3fnuz | float16 or bfloat16 | Per-token/per-group | FP8 quantized |
+
+### Kernel Selection
+
+| M Range | Kernel | Tile Size |
+|---------|--------|-----------|
+| M < 128 | `deepgemm_256x32x64x256` | Small M tile |
+| M >= 128 | `deepgemm_256x128x128x128` | Large M tile |
+
+### Requirements
+
+- **Hardware:** GFX942 (MI300 series) required
+- **Weight layout:** Must be pre-shuffled with `shuffle_weight(w, layout=(16, 16))`
+- **Output:** Pre-allocated, modified in-place
+
+---
+
+## 3. GMM vs DeepGEMM
+
+| Feature | GMM (Triton) | DeepGEMM (CK) |
+|---------|:------------:|:--------------:|
+| **Backend** | Triton | CK-tile (C++/HIP) |
+| **Primary use** | MoE expert routing | Variable-length attention |
+| **Input shape** | `(M, K) @ (G, K, N)` | `(G, max_M, K) @ (G, N, K)^T` |
+| **Output shape** | `(M, N)` | `(G, max_M, N)` |
+| **Quantization** | No | Yes (FP8) |
+| **Bias support** | Yes | No |
+| **Dynamic masking** | No (exact group_sizes) | Yes (masked_m per group) |
+| **Weight layout** | Standard | Shuffled (16x16 blocks) |
+| **Hardware** | All AMD GPUs via Triton | GFX942/GFX950 |
+
+---
+
+## 4. Source Files
+
+| Component | Path |
+|---|---|
+| GMM Python API | `aiter/ops/triton/gmm.py` |
+| GMM Triton kernels | `aiter/ops/triton/_triton_kernels/gmm.py` |
+| GMM utilities | `aiter/ops/triton/utils/gmm_common.py` |
+| GMM tuning configs | `aiter/ops/triton/configs/{arch}-GMM.json` |
+| DeepGEMM Python API | `aiter/ops/deepgemm.py` |
+| DeepGEMM CK kernels | `csrc/ck_deepgemm/deepgemm.cu` |
+| DeepGEMM kernel configs | `csrc/ck_deepgemm/deepgemm_common.py` |
+| Weight shuffle | `aiter/ops/shuffle.py` |
+
+---
+
+## 5. Test Files
+
+| Test | Path |
+|------|------|
+| GMM unit tests | `op_tests/triton_tests/test_gmm.py` |
+| GMM benchmarks | `op_tests/op_benchmarks/triton/bench_gmm.py` |
+| DeepGEMM tests | `op_tests/test_deepgemm.py` |
+| DeepGEMM attention benchmarks | `op_tests/op_benchmarks/triton/bench_deepgemm_attention.py` |

--- a/docs/weight_shuffle_guide.md
+++ b/docs/weight_shuffle_guide.md
@@ -1,0 +1,185 @@
+# AITER Weight Shuffle & Preshuffle Guide
+
+This guide documents the weight shuffle operators in AITER that transform weight tensor layouts for optimized GEMM execution on AMD GPUs. Preshuffling is a one-time cost at weight loading time that enables faster runtime GEMM.
+
+---
+
+## Quick Reference
+
+| Use Case | Function | Layout | Backend |
+|----------|---------|--------|---------|
+| **CK/CKTile GEMM** | `shuffle_weight(w, (16, 16))` | 16×16 blocks | CK |
+| **ASM GEMM** | `shuffle_weight(w, (32, 16))` | 32×16 blocks | ASM |
+| **DeepGEMM** | `shuffle_weight(w, (16, 16))` | 16×16 blocks | CK-tile |
+| **MoE FP4 weights** | `shuffle_weight_a16w4(w, NLane, gate_up)` | FP4-optimized | MoE |
+| **MoE FP4 scales** | `shuffle_scale_a16w4(scales, experts, gate_up)` | MXFP4 scales | MoE |
+
+---
+
+## 1. Core Shuffle Functions
+
+### `shuffle_weight`
+
+Rearranges weight tensor from standard `(N, K)` layout to blocked layout matching kernel access patterns:
+
+```python
+from aiter.ops.shuffle import shuffle_weight
+
+# For CK/CKTile backends
+weight_ck = shuffle_weight(weight_q, layout=(16, 16))
+
+# For ASM backend
+weight_asm = shuffle_weight(weight_q, layout=(32, 16))
+
+# For INT4
+weight_int4 = shuffle_weight(weight_q, layout=(16, 16), use_int4=True)
+```
+
+**Parameters:**
+- `x`: Weight tensor `(N, K)`
+- `layout`: `(IN, IK)` block dimensions — `(16, 16)` for CK, `(32, 16)` for ASM
+- `use_int4`: Enable int4 mode (packed `uint8`)
+
+**Supported dtypes:** `int8`, `float8_e4m3fnuz`, `float4_e2m1fn_x2`, `uint8` (packed int4)
+
+**What it does:** Permutes dimensions `(N, K) → (N//BN, K//BK, BK//K_elem, BN, K_elem) → permute → (N, K)` with optimized memory layout.
+
+### `shuffle_weight_NK`
+
+Alternative shuffle using instruction tile dimensions:
+
+```python
+from aiter.ops.shuffle import shuffle_weight_NK
+
+weight_shuffled = shuffle_weight_NK(weight, inst_N=16, inst_K=16)
+```
+
+### `shuffle_weight_a16w4` (MoE FP4)
+
+Shuffle for A16W4 MoE operations with gate-up fusion:
+
+```python
+from aiter.ops.shuffle import shuffle_weight_a16w4
+
+# weight: [experts_cnt, N, K_pk] where K_pk = K // 2 (packed FP4)
+weight_shuffled = shuffle_weight_a16w4(weight, NLane=16, gate_up=True)
+```
+
+### `shuffle_scale_a16w4` (MoE FP4 Scales)
+
+Shuffle MXFP4 scale tensors for MoE operations:
+
+```python
+from aiter.ops.shuffle import shuffle_scale_a16w4
+
+scale_shuffled = shuffle_scale_a16w4(scales, experts_cnt=64, gate_up=True)
+```
+
+---
+
+## 2. GEMM Integration
+
+### A8W8 FP8 with Preshuffle
+
+```python
+import aiter
+from aiter.ops.shuffle import shuffle_weight
+
+# Quantize
+x_q, x_scale = aiter.pertoken_quant(x, quant_dtype=torch.float8_e4m3fnuz)
+w_q, w_scale = aiter.pertoken_quant(weight, quant_dtype=torch.float8_e4m3fnuz)
+
+# Shuffle (one-time cost)
+w_shuffled = shuffle_weight(w_q, layout=(16, 16))
+
+# Run optimized GEMM
+out = aiter.gemm_a8w8_bpreshuffle(x_q, w_shuffled, x_scale, w_scale, dtype=torch.bfloat16)
+```
+
+### Backend Dispatch
+
+The tuned GEMM system automatically selects the backend based on CSV config lookup:
+
+| Backend | Shuffle Layout | Scale Type | Notes |
+|---------|---------------|------------|-------|
+| CK | `(16, 16)` | Per-tensor | Primary FP8 backend |
+| CKTile | `(16, 16)` | Per-tensor | Alternative CK backend |
+| ASM | `(32, 16)` | Per-tensor | Hand-tuned assembly |
+| ASM Blockscale | `(32, 16)` | Block (128×128) | GFX950 only |
+| Triton AFP4WFP4 | `(16, 16)` | Block (32×32) | FP4 Triton kernels |
+
+### Blockscale Preshuffle
+
+For block-wise quantized GEMM (128×128 blocks):
+
+```python
+# CK blockscale
+w_ck = shuffle_weight(weight_q, layout=(16, 16))
+out = aiter.gemm_a8w8_blockscale_bpreshuffle(x_q, w_ck, x_scale, w_scale, dtype)
+
+# ASM blockscale (GFX950)
+w_asm = shuffle_weight(weight_q, layout=(32, 16))
+out = aiter.gemm_a8w8_blockscale_bpreshuffle_asm(x_q, w_asm, out, x_scale, w_scale)
+```
+
+---
+
+## 3. Why Preshuffle?
+
+Standard weight layouts cause strided memory accesses in GEMM kernels. Preshuffling rearranges data to match the kernel's tile access pattern:
+
+```
+Standard layout: N×K row-major
+    → Strided loads for K-dimension tiles
+    → Bank conflicts, poor cache utilization
+
+Preshuffled layout: (N//BN, K//BK, BN, BK) blocked
+    → Coalesced loads within each tile
+    → Optimal L2 cache reuse
+```
+
+**Trade-off:** One-time shuffle cost at weight loading vs. faster GEMM at every inference step.
+
+---
+
+## 4. Tuning Configuration
+
+Preshuffle-specific config files in `aiter/configs/`:
+
+| File | Description |
+|------|-------------|
+| `a8w8_bpreshuffle_tuned_gemm.csv` | FP8 per-tensor preshuffle configs |
+| `a8w8_blockscale_bpreshuffle_tuned_gemm.csv` | FP8 blockscale preshuffle configs |
+
+**Tuning:**
+```bash
+# A8W8 preshuffle tuning
+python3 csrc/ck_gemm_a8w8_bpreshuffle/gemm_a8w8_bpreshuffle_tune.py \
+    -i aiter/configs/a8w8_bpreshuffle_untuned_gemm.csv \
+    -o aiter/configs/a8w8_bpreshuffle_tuned_gemm.csv \
+    --libtype ck,cktile -k
+```
+
+---
+
+## 5. Source Files
+
+| Component | Path |
+|---|---|
+| Shuffle Python API | `aiter/ops/shuffle.py` |
+| A8W8 GEMM dispatch | `aiter/ops/gemm_op_a8w8.py` |
+| CK preshuffle kernels | `csrc/ck_gemm_a8w8_bpreshuffle/` |
+| CKTile preshuffle kernels | `csrc/cktile_gemm_a8w8_bpreshuffle/` |
+| Blockscale preshuffle kernels | `csrc/ck_gemm_a8w8_blockscale_bpreshuffle/` |
+| Triton FP4 preshuffle | `aiter/ops/triton/gemm/basic/gemm_afp4wfp4.py` |
+| Preshuffle tuning configs | `aiter/configs/a8w8_bpreshuffle_tuned_gemm.csv` |
+
+---
+
+## 6. Test Files
+
+| Test | Path |
+|------|------|
+| A8W8 GEMM (with preshuffle) | `op_tests/test_gemm_a8w8.py` |
+| A8W8 blockscale (with preshuffle) | `op_tests/test_gemm_a8w8_blockscale.py` |
+| AFP4WFP4 (with preshuffle) | `op_tests/triton_tests/gemm/basic/test_gemm_afp4wfp4.py` |


### PR DESCRIPTION
## Summary
- Add **Causal Conv1D** guide — prefill/decode, fused QKV split, speculative decoding, Gluon variants
- Add **Gated Delta Net** guide — fused recurrent, chunk-based, sigmoid gating, GVA support
- Add **Grouped GEMM** guide — GMM (Triton) and DeepGEMM (CK-tile) for MoE and variable-length workloads
- Add **Weight Shuffle & Preshuffle** guide — layout transforms for CK/ASM/Triton GEMM backends
- Add **BERT Padding & Variable-Length** guide — pad/unpad utilities for variable-length attention
- Update **README** with new operator rows and Infrastructure & Tuning section

## Note
This PR includes some README changes that overlap with PR #5 (Tier 1 infrastructure guides). Merge PR #5 first, then rebase this branch to resolve any conflicts.

## Test plan
- [ ] Verify all markdown links resolve correctly
- [ ] Verify API examples match current source code
- [ ] Verify source file and test file paths are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)