### PR TITLE
Triton FA fwd: tuned config for long sequences (gfx942)

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/mha.py
+++ b/aiter/ops/triton/_triton_kernels/attention/mha.py
@@ -882,6 +882,7 @@ def _get_config(
     enable_dropout: bool,
     dtype: torch.dtype,
     has_pe: bool = False,
+    max_seqlen_q: int = 0,
 ):
     if not hasattr(_get_config, "_config_dict"):
         dev = arch_info.get_arch()
@@ -899,5 +900,7 @@ def _get_config(
         return fwd_cfg["pe"]
     elif enable_dropout or dtype == torch.float32:
         return fwd_cfg["dropout_or_fp32"]
+    elif max_seqlen_q >= 8192 and "default_long_seqlen" in fwd_cfg:
+        return fwd_cfg["default_long_seqlen"]
     else:
         return fwd_cfg["default"]

--- a/aiter/ops/triton/attention/mha.py
+++ b/aiter/ops/triton/attention/mha.py
@@ -166,7 +166,8 @@ def _flash_attn_forward(
         dropout_mask = None
 
     if config is None:
-        config = _get_config(enable_dropout, q.dtype, has_pe=pe_head_dim > 0)
+        config = _get_config(enable_dropout, q.dtype, has_pe=pe_head_dim > 0,
+                             max_seqlen_q=max_seqlen_q)
 
     """
     # Tuned for gfx942

--- a/aiter/ops/triton/configs/gfx942-MHA-DEFAULT.json
+++ b/aiter/ops/triton/configs/gfx942-MHA-DEFAULT.json
@@ -18,6 +18,15 @@
       "num_ctas": 1,
       "num_stages": 1
     },
+    "default_long_seqlen": {
+      "BLOCK_M": 256,
+      "BLOCK_N": 64,
+      "PRELOAD_V": false,
+      "waves_per_eu": 2,
+      "num_warps": 8,
+      "num_ctas": 1,
+      "num_stages": 2
+    },
     "pe": {
       "BLOCK_M": 256,
       "BLOCK_N": 64,


### PR DESCRIPTION
## Summary
- Add a `default_long_seqlen` config for Triton flash attention forward on gfx942 (MI300X)
- When `seqlen_q >= 8192`, automatically selects `BLOCK_M=256, num_warps=8, num_stages=2`
- Sequences shorter than 8192 continue using the original `BLOCK_M=128` config — zero performance change

## Benchmark Results (MI300X, GQA hq=64 hk=8 d=128 bf16)

### Non-causal (TFLOPS)
| Shape | Before | After | Improvement | Gap to CK/ASM |
|---|---|---|---|---|
| b=1 s=8192 | 420 | **438** | **+4%** | 1.24x → **1.20x** |
| b=8 s=8192 | 407 | **439** | **+8%** | 1.26x → **1.19x** |

### Causal (TFLOPS)
| Shape | Before | After | Improvement | Gap to CK/ASM |
|---|---|---|---|---|
| b=1 s=8192 | 367 | **380** | **+3%** | 1.26x → **1.22x** |
| b=8 s=8192 | 365 | **390** | **+7%** | 1.32x → **1.25x** |

## Key tuning insights
- `BLOCK_M=256` increases Q tile reuse of K/V data (4x vs 2x per K/V block load)
- `num_stages=2` enables software pipelining of global→LDS prefetch
- `num_warps=8` provides sufficient parallelism to fill the pipeline
- Threshold set to 8192 to ensure zero regressions at shorter seqlens

## Changes
- `gfx942-MHA-DEFAULT.json`: add `default_long_seqlen` config entry
- `_triton_kernels/attention/mha.py`: `_get_config()` accepts `max_seqlen_q` and selects long-seqlen config when `>= 8192`
- `attention/mha.py`: pass `max_seqlen_q` to `_get_config()`

## Test plan
- [x] Verify no regression on seqlen < 8192 workloads ✅
- [x] Verify improvement on seqlen >= 8192 workloads ✅
- [x] `pytest op_tests/triton_tests/attention/test_mha.py` — **7073 passed**, 0 failed ✅