### PR TITLE
Add ENABLE_CK=0 build option for fast Triton-only builds

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -626,11 +626,15 @@ def build_module(
         else:
             sources = exec_blob(blob_gen_cmd, op_dir, src_dir, sources)
 
-        extra_include_paths = [
-            f"{CK_HELPER_DIR}",
-            f"{CK_3RDPARTY_DIR}/include",
-            f"{CK_3RDPARTY_DIR}/library/include",
-        ]
+        extra_include_paths = []
+        if os.path.isdir(CK_3RDPARTY_DIR):
+            extra_include_paths += [
+                f"{CK_HELPER_DIR}",
+                f"{CK_3RDPARTY_DIR}/include",
+                f"{CK_3RDPARTY_DIR}/library/include",
+            ]
+        elif os.path.isdir(CK_HELPER_DIR):
+            extra_include_paths.append(CK_HELPER_DIR)
         if not hipify:
             extra_include_paths += [
                 f"{AITER_CSRC_DIR}/include",


### PR DESCRIPTION
## Summary
- Add `ENABLE_CK=0` env var to skip all 45 CK/ASM-codegen modules, building only 32 lightweight modules (Triton kernels + C++ utilities)
- Detection is dynamic — scans `optCompilerConfig.json` for CK patterns (`CK_DIR`, `py_itfs_ck`, `gen_instances`, `generate.py`, `codegen.py`) rather than hardcoding module names
- Default `ENABLE_CK=1` preserves existing behavior with zero changes

## Changes
- `setup.py`: `ENABLE_CK` env var, conditional `3rdparty` copy (only `ck_helper` when CK disabled), conditional CK_DIR assertion, dynamic CK module exclusion in `get_exclude_ops()`
- `aiter/jit/core.py`: conditional CK include paths based on whether `CK_3RDPARTY_DIR` exists on disk

## Usage
```bash
ENABLE_CK=0 PREBUILD_KERNELS=1 pip install -e .
```

## Test Results
- 31/32 KEEP modules built successfully (1 pre-existing LLVM bug in `module_topk_plain`)
- 9 KEEP-module unit tests passed: activation, aiter_add, aiter_sigmoid, groupnorm, quant, rope, sample, topk_per_row, fused_qk_norm_rope_cache_quant