### PR TITLE
Fix Triton unified_attention constexpr bool-to-int

### DIFF
--- a/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
+++ b/aiter/ops/triton/_triton_kernels/attention/unified_attention.py
@@ -231,7 +231,7 @@ def kernel_unified_attention_2d(
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
         tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
 
-    KV_cache_modifier: tl.constexpr = ".cg" if ALL_DECODE else ""
+    KV_cache_modifier: tl.constexpr = ".cg" if ALL_DECODE == 1 else ""
     # iterate through tiles (now limited to the sliding window range)
     for j in range(tile_start, tile_end):
         seq_offset = j * TILE_SIZE + offs_t
@@ -540,7 +540,7 @@ def kernel_unified_attention_3d(
     # this prefix can be skipped)
     num_tiles = cdiv_fn(max_seq_prefix_len, TILE_SIZE)
 
-    KV_cache_modifier: tl.constexpr = ".cg" if ALL_DECODE else ""
+    KV_cache_modifier: tl.constexpr = ".cg" if ALL_DECODE == 1 else ""
     # iterate through tiles within current segment
     for j in range(
         segm_idx * tiles_per_segment,

--- a/aiter/ops/triton/attention/unified_attention.py
+++ b/aiter/ops/triton/attention/unified_attention.py
@@ -158,7 +158,7 @@ def unified_attention(
     total_num_q_blocks = q.shape[0] // BLOCK_Q + num_seqs
     target_num_prgms = cu_count * 4
     num_2d_prgms = total_num_q_blocks * num_kv_heads
-    ALL_DECODE = max_seqlen_q == 1
+    ALL_DECODE = int(max_seqlen_q == 1)
     # if batch contains a prefill
     if use_2d_kernel(
         head_size,
@@ -213,10 +213,10 @@ def unified_attention(
             BLOCK_SIZE=block_size,
             HEAD_SIZE=head_size,
             HEAD_SIZE_PADDED=triton.next_power_of_2(head_size),
-            USE_ALIBI_SLOPES=use_alibi_slopes,
-            USE_QQ_BIAS=use_qq_bias,
-            USE_SOFTCAP=(softcap > 0),
-            USE_SINKS=(sinks is not None),
+            USE_ALIBI_SLOPES=int(use_alibi_slopes),
+            USE_QQ_BIAS=int(use_qq_bias),
+            USE_SOFTCAP=int(softcap > 0),
+            USE_SINKS=int(sinks is not None),
             SLIDING_WINDOW=SLIDING_WINDOW,
             stride_k_cache_0=k.stride(0),
             stride_k_cache_1=k.stride(1),
@@ -228,7 +228,7 @@ def unified_attention(
             stride_v_cache_3=v.stride(3),
             query_start_len_ptr=cu_seqlens_q,
             num_seqs=num_seqs,
-            USE_FP8=output_scale is not None,
+            USE_FP8=int(output_scale is not None),
             ALL_DECODE=ALL_DECODE,
             **config,
         )
@@ -291,10 +291,10 @@ def unified_attention(
             BLOCK_SIZE=block_size,
             HEAD_SIZE=head_size,
             HEAD_SIZE_PADDED=triton.next_power_of_2(head_size),
-            USE_ALIBI_SLOPES=use_alibi_slopes,
-            USE_QQ_BIAS=use_qq_bias,
-            USE_SOFTCAP=(softcap > 0),
-            USE_SINKS=(sinks is not None),
+            USE_ALIBI_SLOPES=int(use_alibi_slopes),
+            USE_QQ_BIAS=int(use_qq_bias),
+            USE_SOFTCAP=int(softcap > 0),
+            USE_SINKS=int(sinks is not None),
             SLIDING_WINDOW=SLIDING_WINDOW,
             stride_k_cache_0=k.stride(0),
             stride_k_cache_1=k.stride(1),


### PR DESCRIPTION
## Summary
- Convert Python `bool` constexpr arguments to `int` in unified_attention wrapper for ROCm Triton 3.5.x compatibility
- Fix kernel-side constexpr ternary `ALL_DECODE == 1` instead of bool truthiness
- Affected args: `USE_ALIBI_SLOPES`, `USE_QQ_BIAS`, `USE_SOFTCAP`, `USE_SINKS`, `USE_FP8`, `ALL_DECODE`

## Problem
ROCm Triton 3.5.x rejects Python `bool` objects passed as `tl.constexpr` kernel arguments:
```
`if` conditionals can only accept values of type {int, bool, NoneType}, not objects of type bool
```
This breaks prefill attention via `unified_attention` when called from ATOM with models like GPT-OSS-120B.

## Related
- ATOM companion PR: sunway513/ATOM#4
- Dependency: `triton_kernels` package from `ROCm/triton` (`pip install -e /path/to/triton/python/triton_kernels/`)

## Test plan
- [x] Verified with GPT-OSS-120B (head_dim=64, sliding_window=128, MXFP4 MoE) on MI300X
- [x] Triton kernels compile and produce correct outputs for both prefill and decode
- [ ] Run existing AITER Triton attention tests