### PR TITLE
Enable CK-free MOE path for Swiglu+MXFP4 on gfx950

### DIFF
--- a/aiter/fused_moe.py
+++ b/aiter/fused_moe.py
@@ -18,9 +18,56 @@ from aiter.jit.core import AITER_CONFIGS, PY, bd_dir, get_asm_dir, mp_lock
 from aiter.jit.utils.chip_info import get_cu_num, get_gfx
 from aiter.jit.utils.torch_guard import torch_compile_guard
 from aiter.ops.triton.quant.fused_mxfp4_quant import fused_dynamic_mxfp4_quant_moe_sort
+from aiter.ops.triton.moe.moe_align_block_size import moe_align_block_size_triton
 from aiter.utility import fp4_utils
 
 BLOCK_SIZE_M = 32
+
+
+def moe_sorting_triton(
+    topk_ids,
+    topk_weights,
+    num_experts,
+    model_dim,
+    moebuf_dtype,
+    block_size=BLOCK_SIZE_M,
+):
+    device = topk_ids.device
+    M, topk = topk_ids.shape
+    total = topk_ids.numel()
+    max_num_tokens_padded = int(total + num_experts * block_size - topk)
+    max_num_m_blocks = int((max_num_tokens_padded + block_size - 1) // block_size)
+
+    sorted_ids = torch.empty(max_num_tokens_padded, dtype=dtypes.i32, device=device)
+    sorted_expert_ids = torch.empty(max_num_m_blocks, dtype=dtypes.i32, device=device)
+    num_tokens_post_pad = torch.empty(1, dtype=dtypes.i32, device=device)
+
+    moe_align_block_size_triton(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_ids,
+        sorted_expert_ids,
+        num_tokens_post_pad,
+    )
+
+    # Gather sorted_weights from topk_weights using sorted_ids
+    flat_weights = topk_weights.reshape(-1).to(dtypes.fp32)
+    sorted_weights = torch.zeros(
+        max_num_tokens_padded, dtype=dtypes.fp32, device=device
+    )
+    valid_mask = sorted_ids < total
+    clamped_ids = sorted_ids.clamp(min=0, max=total - 1).long()
+    sorted_weights[valid_mask] = flat_weights[clamped_ids[valid_mask]]
+
+    # Build num_valid_ids[2] for compatibility with CK format
+    num_valid_ids = torch.empty(2, dtype=dtypes.i32, device=device)
+    num_valid_ids[0] = num_tokens_post_pad[0]
+    num_valid_ids[1] = num_tokens_post_pad[0]
+
+    moe_buf = torch.empty((M, model_dim), dtype=moebuf_dtype, device=device)
+
+    return sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, moe_buf
 
 
 def moe_sorting(
@@ -65,11 +112,15 @@ def moe_sorting(
             dispatch_policy,
         )
     except Exception as e:
-        logger.error(f"Error in moe_sorting: {e}")
-        logger.error(
-            f"Moe_sorting info: {max_num_tokens_padded=} {block_size=} {num_experts=} {topk=} {topk_ids.shape=}"
+        if expert_mask is not None:
+            logger.error(
+                f"CK moe_sorting failed with expert_mask set, Triton fallback does not support EP masking: {e}"
+            )
+            raise
+        logger.warning(f"CK moe_sorting_fwd unavailable ({e}), falling back to Triton")
+        return moe_sorting_triton(
+            topk_ids, topk_weights, num_experts, model_dim, moebuf_dtype, block_size
         )
-        raise e
     return sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, moe_buf
 
 
@@ -392,6 +443,40 @@ def fused_moe_1stage(
             a2_scale,
             activation,
         )
+    elif quant_type == QuantType.per_1x32 and activation == ActivationType.Swiglu:
+        # Swiglu+per_1x32: skip normal quantization, pass activations directly
+        if q_dtype_a == dtypes.fp8:
+            # fp8 prefill path: convert to fp8 with dummy e8m0 scales
+            a1 = hidden_states.to(dtypes.fp8)
+            M_sort = sorted_ids.shape[0]
+            N = a1.shape[-1]
+            a1_scale = torch.ones(
+                [M_sort, N // 32], dtype=dtypes.fp8_e8m0, device=a1.device
+            )
+        else:
+            # bf16 decode path: pass bf16 activations directly
+            a1 = hidden_states
+            a1_scale = None
+        E, model_dim, inter_dim = get_inter_dim(w1.shape, w2.shape)
+        w1_scale = w1_scale.view(E, -1)
+        w2_scale = w2_scale.view(E, -1)
+        aiter.fmoe_g1u1(
+            moe_buf,
+            a1,
+            w1,
+            w2,
+            sorted_ids,
+            sorted_weights,
+            sorted_expert_ids,
+            num_valid_ids,
+            topk,
+            a1_scale,
+            w1_scale,
+            w2_scale,
+            kernelName,
+            fc2_smooth_scale=None,
+            activation=activation,
+        )
     else:
         quant_func = get_quant(quant_type)
         if hidden_states.dtype != q_dtype_a:
@@ -549,6 +634,8 @@ fused_moe_1stage_dict = {
         (ActivationType.Silu,   QuantType.per_1x128,   dtypes.bf16,     dtypes.fp8,    dtypes.fp8,    True,   False) : aiter.fmoe_fp8_blockscale_g1u1,
         (ActivationType.Silu,   QuantType.per_Token,   dtypes.bf16,    dtypes.bf16,   dtypes.bf16,   False,   False) : aiter.fmoe,
         (ActivationType.Silu,   QuantType.per_Token,   dtypes.bf16,     dtypes.fp8,    dtypes.fp8,    True,   True)  : aiter.fmoe_g1u1_tkw1,
+        (ActivationType.Swiglu, QuantType.per_1x32,   dtypes.bf16,   dtypes.bf16,  dtypes.fp4x2,    True,   False) : aiter.fmoe_g1u1,
+        (ActivationType.Swiglu, QuantType.per_1x32,   dtypes.bf16,    dtypes.fp8,  dtypes.fp4x2,    True,   False) : aiter.fmoe_g1u1,
     }
 }
 # fmt: on
@@ -721,6 +808,8 @@ def get_2stage_cfgs(
                 run_1stage = token > 32
             elif q_type == QuantType.per_Token and q_dtype_w == dtypes.fp8:
                 run_1stage = token > 16
+            elif q_type == QuantType.per_1x32:
+                run_1stage = True
             elif q_type != QuantType.per_1x32:
                 run_1stage = token < 256
 


### PR DESCRIPTION
## Summary
- Add Triton-based `moe_sorting_triton()` fallback when CK `module_moe_sorting` JIT fails (missing `ck_tile/13_moe_sorting/` sources in docker)
- Add Swiglu+per_1x32 entries to gfx950 1-stage dict, routing to ASM `fmoe_g1u1` kernel (CK-free)
- Handle Swiglu activation preparation in `fused_moe_1stage()`: bf16 decode (direct passthrough) and fp8 prefill (dummy e8m0 scales)
- Set `run_1stage=True` for per_1x32 to bypass CK-Tile 2-stage MOE entirely

## Motivation
gpt-oss-120b (MOE model, Swiglu activation, MXFP4/per_1x32 quantization) crashes on MI355X because:
1. `moe_sorting_fwd` JIT fails — CK source directory missing from docker image
2. Swiglu+per_1x32 routes to CK-Tile GEMM `cktile_moe_stage1/stage2` (also CK-dependent)

This PR makes the entire MOE inference path CK-free by using existing Triton sorting + ASM 1-stage kernels.

## Dependency chain (all CK-free)
- `moe_sorting` → Triton `moe_align_block_size_triton` (fallback)
- `fused_moe_1stage` → `fmoe_g1u1` (ASM, `module_moe_asm`)
- `moe_mxfp4_sort` → Triton kernel (already CK-free)
- Activation quantization → Python/Triton (already CK-free)

## Test plan
- [ ] Run gpt-oss 1k/1k benchmark on MI355X with 8 GPUs
- [ ] Verify no `module_moe_sorting` or `module_moe_cktile2stages` JIT compilation in logs
- [ ] Validate output correctness (no NaN/errors)