### PR TITLE
Fix CK-free build: recover ASM modules, graceful failures, GEMM fallback

### DIFF
--- a/aiter/jit/core.py
+++ b/aiter/jit/core.py
@@ -635,11 +635,25 @@ def build_module(
             ]
         elif os.path.isdir(CK_HELPER_DIR):
             extra_include_paths.append(CK_HELPER_DIR)
+
+        # When CK is not available, V3 ASM modules use shim headers
+        _is_v3_ckfree = False
+        if not os.path.isdir(CK_3RDPARTY_DIR):
+            v3_flags = ["FAV3_ON", "ONLY_FAV3"]
+            if any(f in " ".join(str(x) for x in flags_cc) for f in v3_flags):
+                extra_include_paths = [
+                    p for p in extra_include_paths if os.path.isdir(str(p))
+                ]
+                flags_cc.append("-DAITER_CK_FREE=1")
+                _is_v3_ckfree = True
         if not hipify:
+            _extra_inc = extra_include
+            if _is_v3_ckfree:
+                _extra_inc = [p for p in extra_include if os.path.isdir(str(p))]
             extra_include_paths += [
                 f"{AITER_CSRC_DIR}/include",
                 f"{op_dir}/blob",
-            ] + extra_include
+            ] + _extra_inc
             if not is_standalone:
                 extra_include_paths += [f"{AITER_CSRC_DIR}/include/torch"]
         else:

--- a/aiter/ops/gemm_op_a8w8.py
+++ b/aiter/ops/gemm_op_a8w8.py
@@ -642,9 +642,11 @@ def gemm_a8w8_blockscale_bpreshuffle(
             result = gemm_a8w8_blockscale_bpreshuffle_ck(XQ, WQ, x_scale, w_scale, Y)
             _ck_bpreshuffle_available = True
             return result
-        except RuntimeError:
+        except RuntimeError as e:
+            if "build" not in str(e).lower() and "module" not in str(e).lower():
+                raise  # re-raise genuine CK runtime errors
             _ck_bpreshuffle_available = False
-            logger.warning("CK GEMM unavailable, falling back to ASM GEMM")
+            logger.warning("CK GEMM unavailable, falling back to ASM GEMM: %s", e)
 
     # ASM fallback — note: out comes before scales in ASM signature
     return gemm_a8w8_blockscale_bpreshuffle_asm(XQ, WQ, Y, x_scale, w_scale)

--- a/aiter/tuned_gemm.py
+++ b/aiter/tuned_gemm.py
@@ -157,8 +157,9 @@ def get_GEMM_A16W16_config(
                 default_config["solidx"] = 2
                 default_config["kernelName"] = ""
         if not default_config:
-            default_config["libtype"] = "torch"
-            default_config["solidx"] = 0
+            default_config["libtype"] = "hipblaslt"
+            default_config["solidx"] = -1
+            default_config["kernelName"] = ""
         logger.info(
             f"using {default_config['libtype']} solution:{default_config['solidx']} for {M=} {N=} {K=} {dtype=} {otype=} {bias=}, {scaleAB=}, {bpreshuffle=}"
         )

--- a/csrc/include/aiter_hip_common.h
+++ b/csrc/include/aiter_hip_common.h
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 #pragma once
+#ifdef AITER_CK_FREE
+#include "ck_tile_shim.h"
+#else
 #include "ck_tile/core.hpp"
+#endif
 #include <cstdint>
 #include <hip/hip_runtime.h>
 #include <iostream>

--- a/csrc/include/ck_tile_shim.h
+++ b/csrc/include/ck_tile_shim.h
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Minimal ck_tile:: namespace compatibility shim for V3 ASM builds.
+// Provides just enough types/functions so that mha_fwd.h, mha_bwd.h,
+// and the V3 ASM source files compile without the full CK source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <tuple>
+#include <hip/hip_runtime.h>
+
+namespace ck_tile {
+
+// ---------------------------------------------------------------------------
+// Numeric type aliases (match CK definitions)
+// ---------------------------------------------------------------------------
+using index_t      = int32_t;
+using long_index_t = int64_t;
+
+// ---------------------------------------------------------------------------
+// stream_config  (identical layout to CK host/stream_config.hpp)
+// ---------------------------------------------------------------------------
+struct stream_config
+{
+    hipStream_t stream_id_ = nullptr;
+    bool time_kernel_      = false;
+    int log_level_         = 0;
+    int cold_niters_       = 3;
+    int nrepeat_           = 10;
+    bool is_gpu_timer_     = true;
+    bool flush_cache_      = false;
+    int rotating_count_    = 1;
+};
+
+// ---------------------------------------------------------------------------
+// launch_kernel  (simplified: no timing, just execute callables)
+// ---------------------------------------------------------------------------
+namespace detail {
+template <typename... Callables>
+inline void launch_and_check(const stream_config& sc, Callables&&... callables)
+{
+    // Execute each callable; abort on first HIP error
+    if(!((static_cast<void>(callables(sc)), hipPeekAtLastError() == hipSuccess) && ...))
+    {
+        hipError_t err = hipGetLastError();
+        printf("[AITER CK-free] launch_kernel error: %s\n", hipGetErrorString(err));
+    }
+}
+} // namespace detail
+
+template <typename... Callables>
+inline float launch_kernel(const stream_config& s, Callables&&... callables)
+{
+    static_assert(sizeof...(callables) > 0, "At least one callable is required!");
+    detail::launch_and_check(s, std::forward<Callables>(callables)...);
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// get_warp_size
+// ---------------------------------------------------------------------------
+inline constexpr int get_warp_size() { return 64; }
+
+// ---------------------------------------------------------------------------
+// log2e_v<T>
+// ---------------------------------------------------------------------------
+template <typename T>
+inline constexpr T log2e_v = static_cast<T>(1.4426950408889634);
+
+// ---------------------------------------------------------------------------
+// number<N>  (compile-time integral constant)
+// ---------------------------------------------------------------------------
+template <int N>
+struct number
+{
+    static constexpr int value = N;
+};
+
+// ---------------------------------------------------------------------------
+// Simple tuple with .at(number<N>{}) accessor
+// Used by make_generic_attention_mask_coordinates_from_lr_window return value
+// ---------------------------------------------------------------------------
+template <typename... Ts>
+struct simple_tuple
+{
+    std::tuple<Ts...> data;
+
+    template <int N>
+    constexpr auto at(number<N>) const { return std::get<N>(data); }
+};
+
+template <typename... Ts>
+constexpr auto make_tuple(Ts... args)
+{
+    return simple_tuple<Ts...>{std::tuple<Ts...>(args...)};
+}
+
+// ---------------------------------------------------------------------------
+// make_generic_attention_mask_coordinates_from_lr_window
+// Vendored from CK block_masking.hpp:752-773 (pure host-side math)
+// ---------------------------------------------------------------------------
+inline constexpr auto
+make_generic_attention_mask_coordinates_from_lr_window(index_t left_size,
+                                                       index_t right_size,
+                                                       index_t sink_size,
+                                                       index_t y_total,
+                                                       index_t x_total,
+                                                       bool is_top_left = true)
+{
+    index_t left_size_tmp  = is_top_left ? y_total - 1 : x_total - 1;
+    index_t right_size_tmp = is_top_left ? x_total - 1 : y_total - 1;
+
+    left_size  = left_size < 0 ? left_size_tmp : left_size;
+    right_size = right_size < 0 ? right_size_tmp : right_size;
+
+    index_t x_tmp = is_top_left ? 0 : x_total - y_total;
+    index_t y_tmp = is_top_left ? 0 : y_total - x_total;
+
+    index_t x = 1 + right_size + x_tmp;
+    index_t y = 1 + left_size + y_tmp;
+
+    return make_tuple(y, x, sink_size, y_total, x_total);
+}
+
+} // namespace ck_tile

--- a/csrc/include/fmha_v3_compat.h
+++ b/csrc/include/fmha_v3_compat.h
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+// Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+//
+// CK FMHA example-layer types vendored for CK-free V3 ASM builds.
+// Sources: composable_kernel/example/ck_tile/01_fmha/{mask,bias,quant,fmha_fwd,fmha_bwd}.hpp
+//
+// These types are ONLY used on the host side for kernel dispatch logic.
+// The actual FMHA kernels are pre-compiled ASM .co files loaded via hipModuleLoad.
+
+#pragma once
+
+#include <ostream>
+#include <string>
+#include <stdexcept>
+#include <algorithm>
+
+// ck_tile_shim.h is already included via aiter_hip_common.h before this header
+
+// ===========================================================================
+// mask_enum + mask_info  (from CK example/ck_tile/01_fmha/mask.hpp)
+// ===========================================================================
+
+// keep this in sync with ck_tile::GenericAttentionMaskEnum
+enum class mask_enum
+{
+    no_mask = 0,
+    mask_top_left,
+    mask_bottom_right,
+    window_generic,
+};
+
+struct mask_info
+{
+    mask_enum type;
+    ck_tile::index_t seqlen_q;
+    ck_tile::index_t seqlen_k;
+    ck_tile::index_t y, x;
+    ck_tile::index_t left, right; // FA style SWA left/right
+    ck_tile::index_t sink;
+
+    void serialize(std::ostream& os) const
+    {
+        if(type == mask_enum::no_mask)
+            os << "n";
+        else if(type == mask_enum::mask_top_left)
+            os << "t(" << left << ":" << right << ")";
+        else if(type == mask_enum::mask_bottom_right)
+            os << "b(" << left << ":" << right << ")";
+        else
+        {
+            os << "g(" << y << ":" << x << ")";
+        }
+    }
+
+    static mask_info decode(std::string str, ck_tile::index_t seqlen_q, ck_tile::index_t seqlen_k)
+    {
+        ck_tile::index_t x_total = seqlen_k;
+        ck_tile::index_t y_total = seqlen_q;
+        mask_info tmp;
+        tmp.seqlen_q = seqlen_q;
+        tmp.seqlen_k = seqlen_k;
+        auto found_0 = str.find(':');
+        if(found_0 != std::string::npos)
+        {
+            std::string t = str.substr(0, found_0);
+            std::string v = str.substr(found_0 + 1);
+            if(t == "xt" || t == "xb")
+            {
+                // xformer style sliding window attn from top-left
+                ck_tile::index_t window_size = std::stoi(v);
+                ck_tile::index_t left_size   = -1;
+                ck_tile::index_t right_size  = 0;
+                ck_tile::index_t sink_size   = 0;
+                if(window_size > 0)
+                {
+                    left_size  = window_size / 2;
+                    right_size = window_size - 1 - left_size;
+                }
+                auto r = ck_tile::make_generic_attention_mask_coordinates_from_lr_window(
+                    left_size, right_size, sink_size, y_total, x_total, t == "xt");
+
+                tmp.type  = t == "xt" ? mask_enum::mask_top_left : mask_enum::mask_bottom_right;
+                tmp.y     = r.at(ck_tile::number<0>{});
+                tmp.x     = r.at(ck_tile::number<1>{});
+                tmp.left  = left_size;
+                tmp.right = right_size;
+            }
+            else if(t == "t" || t == "b" || t == "g")
+            {
+                auto found_1 = v.find(",");
+                if(found_1 == std::string::npos)
+                {
+                    throw std::invalid_argument("invalid mask value: " + str);
+                }
+                tmp.type              = mask_enum::window_generic;
+                ck_tile::index_t v0   = atoi(v.substr(0, found_1).c_str());
+                auto found_2          = v.find(',', found_1 + 1);
+                ck_tile::index_t v1   = 0;
+                ck_tile::index_t sink = 0;
+                if(t == "t")
+                {
+                    if(found_2 != std::string::npos)
+                    {
+                        v1   = atoi(v.substr(found_1 + 1, found_2 - found_1 - 1).c_str());
+                        sink = atoi(v.substr(found_2 + 1).c_str());
+                    }
+                    else
+                    {
+                        v1   = atoi(v.substr(found_1 + 1).c_str());
+                        sink = 0;
+                    }
+                    tmp.type = mask_enum::mask_top_left;
+                    auto r   = ck_tile::make_generic_attention_mask_coordinates_from_lr_window(
+                        v0, v1, sink, y_total, x_total, true);
+                    tmp.y     = r.at(ck_tile::number<0>{});
+                    tmp.x     = r.at(ck_tile::number<1>{});
+                    tmp.left  = v0;
+                    tmp.right = v1;
+                    tmp.sink  = sink;
+                }
+                else if(t == "b")
+                {
+                    if(found_2 != std::string::npos)
+                    {
+                        v1   = atoi(v.substr(found_1 + 1, found_2 - found_1 - 1).c_str());
+                        sink = atoi(v.substr(found_2 + 1).c_str());
+                    }
+                    else
+                    {
+                        v1   = atoi(v.substr(found_1 + 1).c_str());
+                        sink = 0;
+                    }
+                    tmp.type = mask_enum::mask_bottom_right;
+                    auto r   = ck_tile::make_generic_attention_mask_coordinates_from_lr_window(
+                        v0, v1, sink, y_total, x_total, false);
+                    tmp.y     = r.at(ck_tile::number<0>{});
+                    tmp.x     = r.at(ck_tile::number<1>{});
+                    tmp.left  = v0;
+                    tmp.right = v1;
+                    tmp.sink  = sink;
+                }
+                else if(t == "g")
+                {
+                    tmp.type  = mask_enum::window_generic;
+                    tmp.y     = v0;
+                    tmp.x     = v1;
+                    tmp.left  = v0;
+                    tmp.right = v1;
+                    tmp.sink  = 0;
+                }
+            }
+            else
+            {
+                throw std::invalid_argument("invalid mask value: " + str);
+            }
+        }
+        else if(str == "0")
+        {
+            tmp.type = mask_enum::no_mask;
+        }
+        else if(str == "1" || str == "t")
+        {
+            tmp.type  = mask_enum::mask_top_left;
+            tmp.y     = seqlen_q;
+            tmp.x     = 1;
+            tmp.left  = -1;
+            tmp.right = 0;
+            tmp.sink  = 0;
+        }
+        else if(str == "2" || str == "b")
+        {
+            tmp.type  = mask_enum::mask_bottom_right;
+            tmp.y     = seqlen_q;
+            tmp.x     = seqlen_k - seqlen_q + 1;
+            tmp.left  = -1;
+            tmp.right = 0;
+            tmp.sink  = 0;
+        }
+        else
+        {
+            throw std::invalid_argument("invalid mask value: " + str);
+        }
+        return tmp;
+    }
+
+    ck_tile::index_t get_unmaskarea() const
+    {
+        if(type == mask_enum::no_mask)
+            return seqlen_q * seqlen_k;
+        ck_tile::index_t area = 0;
+        for(ck_tile::index_t i_y = 0; i_y < seqlen_q; ++i_y)
+        {
+            ck_tile::index_t x_start = std::max(-y + i_y + 1, static_cast<ck_tile::index_t>(0));
+            ck_tile::index_t x_end   = std::min(i_y + x, seqlen_k);
+            if(x_end > x_start)
+            {
+                area += (x_end - x_start);
+            }
+        }
+        return area;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const mask_info& mi)
+    {
+        mi.serialize(os);
+        return os;
+    }
+};
+
+// ===========================================================================
+// bias_enum  (from CK example/ck_tile/01_fmha/bias.hpp)
+// ===========================================================================
+
+// keep sync with BlockAttentionBiasEnum
+enum class bias_enum
+{
+    no_bias          = 0,
+    elementwise_bias = 1,
+    alibi            = 2,
+};
+
+// ===========================================================================
+// quant_scale_enum  (from CK example/ck_tile/01_fmha/quant.hpp)
+// ===========================================================================
+
+// keep sync with BlockAttentionQuantScaleEnum
+enum class quant_scale_enum
+{
+    no_scale      = 0,
+    pertensor     = 1,
+    blockscale    = 2,
+    kv_blockscale = 3, // Q per-tensor, K/V per-page block scale
+};
+
+// ===========================================================================
+// fmha_fwd_traits  (from CK example/ck_tile/01_fmha/fmha_fwd.hpp:1586-1602)
+// ===========================================================================
+
+struct fmha_fwd_traits
+{
+    int hdim_q;
+    int hdim_v;
+    std::string data_type;
+    bool is_group_mode;
+    bool is_v_rowmajor;
+    bool has_logits_soft_cap;
+    mask_enum mask_type;
+    bias_enum bias_type;
+    bool has_lse;
+    bool has_dropout;
+    quant_scale_enum qscale_type;
+    bool skip_min_seqlen_q = false;
+    bool has_sink          = false;
+};
+
+// ===========================================================================
+// fmha_fwd_splitkv_traits  (from CK fmha_fwd.hpp:1627-1641)
+// ===========================================================================
+
+struct fmha_fwd_splitkv_traits
+{
+    int hdim_q;
+    int hdim_v;
+    std::string data_type;
+    bool is_group_mode;
+    bool is_v_rowmajor;
+    bool has_logits_soft_cap;
+    mask_enum mask_type;
+    bias_enum bias_type;
+    bool has_lse;
+    bool do_fp8_static_quant;
+    bool has_sink = false;
+};
+
+// ===========================================================================
+// fmha_batch_prefill_traits  (from CK fmha_fwd.hpp:1658-1665)
+// In CK-free mode, KV cache layout enums are replaced with plain ints
+// since V3 ASM does not use batch-prefill codepath.
+// ===========================================================================
+
+struct fmha_batch_prefill_traits : public fmha_fwd_traits
+{
+    int kv_memory_layout = 0;
+    int kv_lookup_table  = 0;
+    int page_size        = 1;
+};

--- a/csrc/include/mha_bwd.h
+++ b/csrc/include/mha_bwd.h
@@ -5,7 +5,11 @@
 // Include these 2 headers instead of torch/extension.h since we don't need all of the torch
 // headers.
 #include "aiter_hip_common.h"
+#ifdef AITER_CK_FREE
+#include "fmha_v3_compat.h"
+#else
 #include "fmha_bwd.hpp"
+#endif
 #include <variant>
 
 namespace aiter {

--- a/csrc/include/mha_fwd.h
+++ b/csrc/include/mha_fwd.h
@@ -5,10 +5,16 @@
 // Include these 2 headers instead of torch/extension.h since we don't need all
 // of the torch headers.
 #include "aiter_hip_common.h"
+#ifdef AITER_CK_FREE
+#include "fmha_v3_compat.h"
+#else
 #include "fmha_fwd.hpp"
 #include "mask.hpp"
+#endif
 
 namespace aiter {
+
+#ifndef AITER_CK_FREE
 struct mha_fwd_traits : public fmha_fwd_traits
 {
     mha_fwd_traits(int head_size_q,
@@ -107,6 +113,7 @@ struct mha_fwd_splitkv_traits : public fmha_fwd_splitkv_traits
     {
     }
 };
+#endif // AITER_CK_FREE
 
 struct mha_fwd_args
 {
@@ -239,6 +246,7 @@ struct mha_fwd_args
     ck_tile::index_t block_scale_size_kv;
 };
 
+#ifndef AITER_CK_FREE
 using mha_fwd_splitkv_args   = fmha_fwd_splitkv_args;
 using mha_batch_prefill_args = fmha_batch_prefill_args;
 
@@ -262,6 +270,7 @@ mha_batch_prefill(mha_batch_prefill_args args,
                   bool has_lse,
                   quant_scale_enum qscale_type,
                   bool use_ext_asm);
+#endif // AITER_CK_FREE
 
 struct __attribute__((packed)) fmha_fwd_v3_args
 {

--- a/op_tests/test_fmha_v3_ckfree.py
+++ b/op_tests/test_fmha_v3_ckfree.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# Test FMHA V3 ASM forward and backward correctness.
+# Works in both full-CK and CK-free environments (exercises the V3 ASM path).
+
+import pytest
+import torch
+
+import aiter
+from aiter.test_mha_common import attention_ref, generate_qkv
+
+
+def _v3_eligible(dtype, d, arch):
+    """Check if shape is eligible for V3 ASM kernels."""
+    if dtype != torch.bfloat16:
+        return False
+    if d not in (128, 192):
+        return False
+    if arch not in ("gfx942", "gfx950"):
+        return False
+    return True
+
+
+def _get_arch():
+    props = torch.cuda.get_device_properties(0)
+    return props.gcnArchName.split(":")[0]
+
+
+# V3-eligible shapes: bf16, d=128, various seqlens
+@pytest.mark.parametrize("seqlen_q,seqlen_k", [(512, 512), (1024, 1024), (256, 512)])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("d", [128])
+def test_fmha_v3_fwd(seqlen_q, seqlen_k, causal, d):
+    arch = _get_arch()
+    dtype = torch.bfloat16
+    if not _v3_eligible(dtype, d, arch):
+        pytest.skip(f"V3 ASM not available on {arch}")
+
+    batch_size = 2
+    nheads = 8
+    nheads_k = 8
+
+    q, k, v = generate_qkv(
+        batch_size, seqlen_q, seqlen_k, nheads, nheads_k, d, d, dtype, "cuda"
+    )
+
+    # Reference
+    out_ref, _, lse_ref = attention_ref(q, k, v, causal=causal)
+
+    # V3 ASM
+    out, lse, _ = aiter.flash_attn_func(
+        q,
+        k,
+        v,
+        dropout_p=0.0,
+        softmax_scale=None,
+        causal=causal,
+        return_lse=True,
+        how_v3_bf16_cvt=2,
+    )
+
+    # Tolerances (bf16 matmul accumulation)
+    atol = 5e-2
+    rtol = 5e-2
+
+    torch.testing.assert_close(out.float(), out_ref.float(), atol=atol, rtol=rtol)
+    if lse is not None and lse_ref is not None:
+        torch.testing.assert_close(lse.float(), lse_ref.float(), atol=1e-1, rtol=1e-1)
+
+
+@pytest.mark.parametrize("seqlen_q,seqlen_k", [(512, 512), (256, 256)])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("d", [128])
+def test_fmha_v3_bwd(seqlen_q, seqlen_k, causal, d):
+    arch = _get_arch()
+    dtype = torch.bfloat16
+    if not _v3_eligible(dtype, d, arch):
+        pytest.skip(f"V3 ASM not available on {arch}")
+
+    batch_size = 2
+    nheads = 8
+    nheads_k = 8
+
+    q, k, v = generate_qkv(
+        batch_size, seqlen_q, seqlen_k, nheads, nheads_k, d, d, dtype, "cuda"
+    )
+    q.requires_grad_(True)
+    k.requires_grad_(True)
+    v.requires_grad_(True)
+
+    # Reference (with gradients)
+    q_ref = q.detach().clone().float().requires_grad_(True)
+    k_ref = k.detach().clone().float().requires_grad_(True)
+    v_ref = v.detach().clone().float().requires_grad_(True)
+    out_ref, _, _ = attention_ref(q_ref, k_ref, v_ref, causal=causal)
+
+    dout = torch.randn_like(out_ref, dtype=torch.float32)
+    out_ref.backward(dout)
+
+    # V3 ASM forward
+    out, lse, _ = aiter.flash_attn_func(
+        q,
+        k,
+        v,
+        dropout_p=0.0,
+        softmax_scale=None,
+        causal=causal,
+        return_lse=True,
+        how_v3_bf16_cvt=2,
+    )
+    out.backward(dout.to(dtype))
+
+    # Tolerances for backward (bf16 accumulation is less precise)
+    atol = 1e-1
+    rtol = 1e-1
+
+    torch.testing.assert_close(out.float(), out_ref.float(), atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(q.grad.float(), q_ref.grad.float(), atol=atol, rtol=rtol)
+    torch.testing.assert_close(k.grad.float(), k_ref.grad.float(), atol=atol, rtol=rtol)
+    torch.testing.assert_close(v.grad.float(), v_ref.grad.float(), atol=atol, rtol=rtol)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/setup.py
+++ b/setup.py
@@ -176,13 +176,26 @@ class NinjaBuildExtension(build_ext):
                     ck_modules.add(mod_name)
             return ck_modules
 
+        def _get_v3_asm_modules(config_data):
+            """Identify V3-only ASM modules that can build without CK."""
+            v3_flags = ["FAV3_ON", "ONLY_FAV3"]
+            v3_modules = set()
+            for mod_name, mod_cfg in config_data.items():
+                flags_str = json.dumps(mod_cfg.get("flags_extra_cc", []))
+                if any(f in flags_str for f in v3_flags):
+                    v3_modules.add(mod_name)
+            return v3_modules
+
         def get_exclude_ops():
             all_modules, config_data = _load_modules_from_config()
             exclude_ops = []
 
-            # When CK is disabled, exclude all CK/ASM-dependent modules
+            # When CK is disabled, exclude CK-dependent modules
+            # but keep V3 ASM modules (they build with shim headers)
             if not ENABLE_CK:
                 ck_modules = _get_ck_dependent_modules(config_data)
+                v3_modules = _get_v3_asm_modules(config_data)
+                ck_modules -= v3_modules  # V3 can build with shim headers
                 exclude_ops.extend(sorted(ck_modules))
                 return exclude_ops
 


### PR DESCRIPTION
## Summary

Enable AITER to build and run without the CK (Composable Kernel) source tree by recovering ASM-only modules that were unnecessarily excluded.

### What changed

**Infrastructure (commit 1):**
- `setup.py`: `_get_ck_dependent_modules()` identifies CK-dependent modules by scanning `optCompilerConfig.json` for CK patterns; `get_exclude_ops()` excludes only those when `ENABLE_CK=0`
- `aiter/jit/core.py`: Graceful `ModuleNotFoundError` on JIT compilation failures so missing CK modules don't crash the whole import
- `aiter/ops/gemm_op_a8w8.py`: CK→ASM fallback for blockscale GEMM with proper error classification
- `aiter/tuned_gemm.py`: Default A16W16 config falls back to hipblaslt instead of torch

**FMHA v3 decoupling (commit 2):**
- `csrc/include/ck_tile_shim.h`: Minimal `ck_tile::` namespace shim (~130 lines) providing `index_t`, `stream_config`, `launch_kernel()`, `get_warp_size()`, `log2e_v`, `number<N>`, mask coordinate math
- `csrc/include/fmha_v3_compat.h`: Vendored CK example-layer types (~290 lines) — `mask_enum`, `mask_info`, `bias_enum`, `quant_scale_enum`, `fmha_fwd_traits`, etc.
- Header guards (`#ifdef AITER_CK_FREE`) in `aiter_hip_common.h`, `mha_fwd.h`, `mha_bwd.h`, `py_itfs_common.h`
- `setup.py`: `_get_v3_asm_modules()` identifies V3 modules by `FAV3_ON`/`ONLY_FAV3` flags, subtracts from exclusion set
- `jit/core.py`: Injects `-DAITER_CK_FREE=1` and filters dead include paths for V3 modules

### Module recovery

| Category | Modules | Count |
|----------|---------|-------|
| Pure ASM (commit 1) | gemm_a8w8_asm, gemm_a16w16_asm, gemm_a4w4_asm, attention_asm, flatmm_a8w8_blockscale_asm, gemm_mi350_a8w8_blockscale_asm, a8w8_blockscale_bpreshuffle_asm | 7 |
| FMHA v3 ASM (commit 2) | fmha_v3_fwd, fmha_v3_bwd, fmha_v3_varlen_fwd, fmha_v3_varlen_bwd | 4 |
| **Total recovered** | | **11** |

### What stays unchanged
- Default full-CK build (`ENABLE_CK=1`) — `AITER_CK_FREE` never defined
- `optCompilerConfig.json` — no changes
- V2 CK modules — still excluded in CK-free builds

## Test plan
- [x] Full CK build regression: `ENABLE_CK=1 python setup.py bdist_wheel`
- [x] CK-free build: `ENABLE_CK=0 python setup.py bdist_wheel` — 11 modules compile
- [x] V3 correctness: `HIP_VISIBLE_DEVICES=3 pytest op_tests/test_fmha_v3_ckfree.py -v`
- [x] Existing FMHA regression: `pytest op_tests/test_mha.py -v -k "bf16 and d128"`