### PR TITLE
Add Triton fallback for fused_rope_rms (QKNorm+RoPE)

### DIFF
--- a/aiter/__init__.py
+++ b/aiter/__init__.py
@@ -88,6 +88,7 @@ from .ops.trans_ragged_layout import *  # noqa: F403,E402
 from .ops.sample import *  # noqa: F403,E402
 from .ops.fused_qk_norm_mrope_cache_quant import *  # noqa: F403,E402
 from .ops.fused_qk_norm_rope_cache_quant import *  # noqa: F403,E402
+from .rotary_embedding import fused_rope_rms  # noqa: F401,E402
 from .ops.groupnorm import *  # noqa: F403,E402
 from .ops.mhc import *  # noqa: F403,E402
 from .ops.causal_conv1d import *  # noqa: F403,E402

--- a/aiter/rotary_embedding.py
+++ b/aiter/rotary_embedding.py
@@ -1293,21 +1293,20 @@ class RotaryEmbeddingFusedQKNorm(nn.Module):
             else:
                 return q_out, None, None
         else:
-            raise NotImplementedError("fused_rope_rms not supported yet")
-            # fused_rope_rms(
-            #     qkv,
-            #     q_weight,
-            #     k_weight,
-            #     self.cos_sin_cache,
-            #     positions,
-            #     num_tokens,
-            #     num_heads_q,
-            #     num_heads_k,
-            #     num_heads_v,
-            #     self.head_size,
-            #     self.is_neox_style,
-            #     eps,
-            # )
+            fused_rope_rms(
+                qkv,
+                q_weight,
+                k_weight,
+                self.cos_sin_cache,
+                positions,
+                num_tokens,
+                num_heads_q,
+                num_heads_k,
+                num_heads_v,
+                self.head_size,
+                self.is_neox_style,
+                eps,
+            )
             q_size = num_heads_q * self.head_size
             k_size = num_heads_k * self.head_size
             v_size = num_heads_v * self.head_size
@@ -1316,6 +1315,67 @@ class RotaryEmbeddingFusedQKNorm(nn.Module):
             q, k, v = qkv.split([q_size, k_size, v_size], dim=-1)
 
             return q, k, v
+
+
+def fused_rope_rms(
+    qkv,
+    q_weight,
+    k_weight,
+    cos_sin_cache,
+    positions,
+    num_tokens,
+    num_heads_q,
+    num_heads_k,
+    num_heads_v,
+    head_size,
+    is_neox_style,
+    eps,
+):
+    """Fused QK-RMSNorm + RoPE on packed QKV tensor (in-place).
+    Triton fallback for the HIP fused kernel.
+    """
+    from aiter.ops.triton.normalization.rmsnorm import rmsnorm_forward_inference
+    from aiter.ops.triton.rope.rope import (
+        rope_cached_thd_positions_2c_fwd_inplace,
+    )
+
+    q_size = num_heads_q * head_size
+    k_size = num_heads_k * head_size
+    v_size = num_heads_v * head_size
+
+    qkv_2d = qkv.view(num_tokens, q_size + k_size + v_size)
+    q, k, _v = qkv_2d.split([q_size, k_size, v_size], dim=-1)
+
+    # Per-head RMSNorm: [T, H*D] -> [T*H, D] so rmsnorm operates per-head
+    q_normed = rmsnorm_forward_inference(
+        q.reshape(num_tokens * num_heads_q, head_size), q_weight, eps
+    )
+    q.copy_(q_normed.view(num_tokens, q_size))
+
+    k_normed = rmsnorm_forward_inference(
+        k.reshape(num_tokens * num_heads_k, head_size), k_weight, eps
+    )
+    k.copy_(k_normed.view(num_tokens, k_size))
+
+    # RoPE in-place
+    q_rope = q.view(num_tokens, num_heads_q, head_size)
+    k_rope = k.view(num_tokens, num_heads_k, head_size)
+
+    half = cos_sin_cache.shape[-1] // 2
+    cos = cos_sin_cache[:, :half]
+    sin = cos_sin_cache[:, half:]
+    rotate_style = 0 if is_neox_style else 1
+
+    rope_cached_thd_positions_2c_fwd_inplace(
+        q_rope,
+        k_rope,
+        cos,
+        sin,
+        positions,
+        rotate_style,
+        reuse_freqs_front_part=True,
+        nope_first=False,
+    )
 
 
 class MRotaryEmbeddingQKNormFused(RotaryEmbeddingFusedQKNorm):


### PR DESCRIPTION
## Summary
- Implement `fused_rope_rms` as a standalone function using existing Triton RMSNorm + RoPE kernels
- Replace `NotImplementedError` in `RotaryEmbeddingFusedQKNorm.forward()` with working Triton fallback
- Export `fused_rope_rms` from `aiter/__init__.py` for ATOM's `from aiter import fused_rope_rms`

## Motivation
ATOM nightly's `qwen3_moe.py` calls `from aiter import fused_rope_rms`, but AITER hasn't shipped the Python binding yet (only HIP C++ kernel exists). This unblocks Qwen3-MoE on CK-free builds and also works as a general fallback.

## Implementation
- **Per-head RMSNorm via reshape**: `[T, H*D]` → `[T*H, D]` so `rmsnorm_forward_inference` (normalizes dim=-1) works per-head
- **In-place via views**: `q, k` from `qkv.split()` share qkv's storage; `q.copy_(normed)` + rope inplace writes back through views
- **cos_sin_cache split**: AITER concatenates `[cos, sin]` along last dim → split at midpoint for Triton rope kernel

## Files Changed
| File | Change |
|------|--------|
| `aiter/rotary_embedding.py` | +Triton imports, +`fused_rope_rms()` function, replace `NotImplementedError` with fallback call |
| `aiter/__init__.py` | +`fused_rope_rms` export |

## Test plan
- [ ] `python -c "from aiter import fused_rope_rms; print('OK')"`
- [ ] Run ATOM nightly with Qwen3-235B-MoE on MI355X (CK-free build)
- [ ] Verify numerical correctness vs HIP fused kernel (when available)